### PR TITLE
Fix flow complaining that href and className for Button.js

### DIFF
--- a/whinepad3/js/source/components/Button.js
+++ b/whinepad3/js/source/components/Button.js
@@ -4,11 +4,11 @@ import React from 'react';
 import classNames from 'classnames';
 
 type Props = {
-  href: ?string,
-  className: ?string,
+  href?: ?string,
+  className?: ?string,
 };
 
-const Button = (props: Props) => 
+const Button = (props: Props) =>
   props.href
     ? <a {...props} className={classNames('Button', props.className)} />
     : <button {...props} className={classNames('Button', props.className)} />


### PR DESCRIPTION
Hi Stoyan,

Finished reading your book. Love it! I found this issue below with flow.

```
js/source/discover.js:28
 28:     <div>Button with onClick: <Button onClick={() => alert('ouch')}>Click me</Button></div>
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ React element `Button`
 11: const Button = (props: Props) =>
                            ^^^^^ property `className`. Property not found in. See: js/source/components/Button.js:11
 28:     <div>Button with onClick: <Button onClick={() => alert('ouch')}>Click me</Button></div>
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ props of React element `Button`
js/source/discover.js:28
 28:     <div>Button with onClick: <Button onClick={() => alert('ouch')}>Click me</Button></div>
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ React element `Button`
 11: const Button = (props: Props) =>
                            ^^^^^ property `href`. Property not found in. See: js/source/components/Button.js:11
 28:     <div>Button with onClick: <Button onClick={() => alert('ouch')}>Click me</Button></div>
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ props of React element `Button`
```

The fix allows these two to be "undefined".
