### PR TITLE
Avoids a JavaScript warning/error on some platforms

### DIFF
--- a/chapters/03.02.table-th-td.html
+++ b/chapters/03.02.table-th-td.html
@@ -26,7 +26,7 @@
           ),
         },
 
-        getInitialState() {
+        getInitialState: function() {
           return {data: this.props.initialData};
         },
         


### PR DESCRIPTION
Method definition shorthands may not be supported on all platforms