### PR TITLE
Whinepad: Let 0 be defaultValue of rating for a new record

### DIFF
--- a/whinepad2/js/source/components/Form.js
+++ b/whinepad2/js/source/components/Form.js
@@ -13,21 +13,21 @@ type Props = {
 };
 
 class Form extends Component {
-  
+
   props: Props;
-  
+
   getData(): Object {
     let data: Object = {};
-    this.props.fields.forEach((field: FormInputField) => 
+    this.props.fields.forEach((field: FormInputField) =>
       data[field.id] = this.refs[field.id].getValue()
     );
     return data;
   }
-  
+
   render() {
     return (
       <form className="Form">{this.props.fields.map((field: FormInputField) => {
-        const prefilled: FormInputFieldValue = (this.props.initialData && this.props.initialData[field.id]) || '';
+        const prefilled: ?FormInputFieldValue = this.props.initialData && this.props.initialData[field.id];
         if (!this.props.readonly) {
           return (
             <div className="FormRow" key={field.id}>

--- a/whinepad2/js/source/components/FormInput.js
+++ b/whinepad2/js/source/components/FormInput.js
@@ -17,9 +17,9 @@ export type FormInputField = {
 };
 
 class FormInput extends Component {
-  
+
   props: FormInputField;
-  
+
   static defaultProps = {
     type: 'input',
   };
@@ -41,7 +41,7 @@ class FormInput extends Component {
         return (
           <input
             {...common}
-            type="number" 
+            type="number"
             defaultValue={this.props.defaultValue || new Date().getFullYear()} />
         );
       case 'suggest':
@@ -50,7 +50,7 @@ class FormInput extends Component {
         return (
           <Rating
             {...common}
-            defaultValue={parseInt(this.props.defaultValue, 10)} />
+            defaultValue={this.props.defaultValue} />
         );
       case 'text':
         return <textarea {...common} />;

--- a/whinepad3/js/source/components/Form.js
+++ b/whinepad3/js/source/components/Form.js
@@ -13,10 +13,10 @@ type Props = {
 };
 
 class Form extends Component {
-  
+
   fields: Array<Object>;
   initialData: ?Object;
-  
+
   constructor(props: Props) {
     super(props);
     this.fields = CRUDStore.getSchema();
@@ -24,19 +24,19 @@ class Form extends Component {
       this.initialData = CRUDStore.getRecord(this.props.recordId);
     }
   }
-  
+
   getData(): Object {
     let data: Object = {};
-    this.fields.forEach((field: FormInputField) => 
+    this.fields.forEach((field: FormInputField) =>
       data[field.id] = this.refs[field.id].getValue()
     );
     return data;
   }
-  
+
   render() {
     return (
       <form className="Form">{this.fields.map((field: FormInputField) => {
-        const prefilled: FormInputFieldValue = (this.initialData && this.initialData[field.id]) || '';
+        const prefilled: ?FormInputFieldValue = this.initialData && this.initialData[field.id];
         if (!this.props.readonly) {
           return (
             <div className="FormRow" key={field.id}>

--- a/whinepad3/js/source/components/FormInput.js
+++ b/whinepad3/js/source/components/FormInput.js
@@ -17,13 +17,13 @@ export type FormInputField = {
 };
 
 class FormInput extends Component {
-  
+
   props: FormInputField;
-  
+
   static defaultProps = {
     type: 'input',
   };
-    
+
   getValue(): FormInputFieldValue {
     return 'value' in this.refs.input
       ? this.refs.input.value
@@ -41,7 +41,7 @@ class FormInput extends Component {
         return (
           <input
             {...common}
-            type="number" 
+            type="number"
             defaultValue={this.props.defaultValue || new Date().getFullYear()} />
         );
       case 'suggest':
@@ -50,7 +50,7 @@ class FormInput extends Component {
         return (
           <Rating
             {...common}
-            defaultValue={parseInt(this.props.defaultValue, 10)} />
+            defaultValue={this.props.defaultValue} />
         );
       case 'text':
         return <textarea {...common} />;


### PR DESCRIPTION
**Problem**: If you do not click a star when you add a new records, the value of rating is `NaN` because of `parseInt('', 10)`. `JSON.stringify` writes `NaN` as `null`, therefore `toString` will fail during some text searches in the next session when the data has been deserialized.

**Solution**: Delete 2 conditional expressions at intermediate levels of the component tree so leaf components receive `undefined` as `defaultValue` of fields for a new record.

**Steps to verify** with console pane open in the browser:

1. Given the default record, type *z* in the search box. Actual and expected result is no records match.
2. Click **add** and then click **Add** to add an empty record.
3. Type **z** in the search box. Actual and expected result is no records match.
4. Type **nan** in the search box. Unexpected result is the new record matches.
5. Clear the search box, and then refresh the page to cause Whinepad to read the data from storage.
6. Type **z** in the search box. Unexpected result is `TypeError: row[fields[f]] is null`

Sorry about the whitespace changes. Atom editor has to make its mark ;)

P.S. Thank you very much for writing React Up & Running! Your previous JavaScript Patterns was super helpful to me too.